### PR TITLE
DD3 Handmoves List insertion order fix

### DIFF
--- a/GDO.Apps.DD3/Web/DD3/Control.cshtml
+++ b/GDO.Apps.DD3/Web/DD3/Control.cshtml
@@ -618,7 +618,7 @@
                                 //Extract to hosted directory, overwrites
                                 entry.ExtractToFile(path + entry.Name, true);
                                 //Add to database.txt
-                                database.Add(entry.Name);
+                                database.Insert(0, entry.Name);
                             }
                         }
                     }
@@ -631,7 +631,7 @@
                     //Put on disk
                     file.SaveAs(path + filename);
                     //Add to database.txt
-                    database.Add(filename);
+                    database.Insert(0, filename);
                 }
                 else //Is not an Image
                 {


### PR DESCRIPTION
Uploaded files weren't displayed in expected order: Last uploaded on top
I replaced the list push_back to a list.push_front, C# equivalent

Seems to fix the issue, on my local machine.

Note that I'm opening a merge request without testing since it's a 2 lines diff on a control panel file anyways.
