### PR TITLE
Responsive layout and config to open blank black page

### DIFF
--- a/GDO.Apps.StaticHTML/Configurations/StaticHTML/Responsive.json
+++ b/GDO.Apps.StaticHTML/Configurations/StaticHTML/Responsive.json
@@ -1,0 +1,4 @@
+﻿{
+  "url": "http://www.imperial.ac.uk",
+  "responsiveMode":  true 
+}

--- a/GDO.Apps.StaticHTML/Configurations/StaticHTML/ResponsiveBlack.json
+++ b/GDO.Apps.StaticHTML/Configurations/StaticHTML/ResponsiveBlack.json
@@ -1,0 +1,4 @@
+﻿{
+  "url": "/Data/StaticHTML/blankBlack.html",
+  "responsiveMode":  true 
+}

--- a/GDO.Apps.StaticHTML/Data/StaticHTML/blankblack.html
+++ b/GDO.Apps.StaticHTML/Data/StaticHTML/blankblack.html
@@ -1,0 +1,9 @@
+﻿<HTML>
+<HEAD>
+    <TITLE>BlankBlack</TITLE>
+	<style>
+	</style>
+</HEAD>
+<BODY BGCOLOR="00000000">
+</BODY>
+</HTML>

--- a/GDO.Apps.StaticHTML/GDO.Apps.StaticHTML.csproj
+++ b/GDO.Apps.StaticHTML/GDO.Apps.StaticHTML.csproj
@@ -124,9 +124,12 @@
     <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Data\StaticHTML\blankblack.html" />
     <Content Include="Data\StaticHTML\sample.html" />
     <Content Include="packages.config" />
     <Content Include="Configurations\StaticHTML\Matrix.json" />
+    <Content Include="Configurations\StaticHTML\Responsive.json" />
+    <Content Include="Configurations\StaticHTML\ResponsiveBlack.json" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/GDO.Apps.StaticHTML/Scripts/StaticHTML/gdo.apps.staticHTML.js
+++ b/GDO.Apps.StaticHTML/Scripts/StaticHTML/gdo.apps.staticHTML.js
@@ -1,64 +1,137 @@
 ﻿$(function () {
     gdo.consoleOut('.StaticHTML', 1, 'Loaded StaticHTML JS');
-    $.connection.staticHTMLAppHub.client.receiveURL = function (instanceId,url) {
+    $.connection.staticHTMLAppHub.client.receiveURL = function (instanceId, url, responsiveMode) {
         if (gdo.clientMode == gdo.CLIENT_MODE.CONTROL) {
-            gdo.consoleOut('.StaticHTML', 1, 'Instance - ' + instanceId + ": Received URL : " + url);
+            gdo.consoleOut('.StaticHTML', 1, 'Instance - ' + instanceId + ": Received URL : " + url + " with responsive mode set " + responsiveMode);
             $("iframe").contents().find("#html_frame")
                 .attr("src", url);
         } else if (gdo.clientMode == gdo.CLIENT_MODE.NODE) {
-            gdo.consoleOut('.StaticHTML', 1, 'Instance - ' + instanceId + ": Received URL : " + url);
-            $("iframe").contents().find("#wrapper")
-                .css("width", gdo.net.section[gdo.net.instance[instanceId].sectionId].width / gdo.net.section[gdo.net.instance[instanceId].sectionId].cols + "px")
-                .css("height", gdo.net.section[gdo.net.instance[instanceId].sectionId].height / gdo.net.section[gdo.net.instance[instanceId].sectionId].rows + "px");
+            gdo.consoleOut('.StaticHTML',
+                1,
+                'Instance - ' + instanceId + ": Received URL : " + url + " with responsive mode set " + responsiveMode);
+            $("iframe")
+                .contents()
+                .find("#wrapper")
+                .css("width",
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].width /
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].cols +
+                    "px")
+                .css("height",
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].height /
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].rows +
+                    "px");
 
+            if (!responsiveMode) {
                 var s;
-                if(gdo.net.section[gdo.net.instance[instanceId].sectionId].cols > 1){
-                    var scale = "scale("+gdo.net.section[gdo.net.instance[instanceId].sectionId].cols+")";
-                }else{
+                if (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols > 1) {
+                    var scale = "scale(" + gdo.net.section[gdo.net.instance[instanceId].sectionId].cols + ")";
+                } else {
                     var scale = "scale(1.01)";
                 }
 
-            if(gdo.net.section[gdo.net.instance[instanceId].sectionId].cols > gdo.net.section[gdo.net.instance[instanceId].sectionId].rows){
+                if (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols >
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].rows) {
 
-                var offsetX = gdo.net.node[gdo.clientId].sectionCol * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols-1));
-                var offsetY = gdo.net.node[gdo.clientId].sectionRow * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows+(gdo.net.section[gdo.net.instance[instanceId].sectionId].cols - gdo.net.section[gdo.net.instance[instanceId].sectionId].rows)-1));
-                var origin = offsetX + "% " + offsetY + "%";
-                var width = gdo.net.section[gdo.net.instance[instanceId].sectionId].width / gdo.net.section[gdo.net.instance[instanceId].sectionId].cols;
-                var height = gdo.net.section[gdo.net.instance[instanceId].sectionId].height / gdo.net.section[gdo.net.instance[instanceId].sectionId].rows;
+                    var offsetX = gdo.net.node[gdo.clientId].sectionCol *
+                    (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols - 1));
+                    var offsetY = gdo.net.node[gdo.clientId].sectionRow *
+                    (100 /
+                    (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows +
+                        (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols -
+                            gdo.net.section[gdo.net.instance[instanceId].sectionId].rows) -
+                        1));
+                    var origin = offsetX + "% " + offsetY + "%";
+                    var width = gdo.net.section[gdo.net.instance[instanceId].sectionId].width /
+                        gdo.net.section[gdo.net.instance[instanceId].sectionId].cols;
+                    var height = gdo.net.section[gdo.net.instance[instanceId].sectionId].height /
+                        gdo.net.section[gdo.net.instance[instanceId].sectionId].rows;
 
-            }else if(gdo.net.section[gdo.net.instance[instanceId].sectionId].cols < gdo.net.section[gdo.net.instance[instanceId].sectionId].rows){
+                } else if (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols <
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].rows) {
 
-                if(gdo.net.section[gdo.net.instance[instanceId].sectionId].cols == 1){
-                    var offsetX = gdo.net.node[gdo.clientId].sectionCol * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols));
-                    var offsetY = 100 * gdo.net.node[gdo.clientId].sectionRow * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows*(gdo.net.section[gdo.net.instance[instanceId].sectionId].cols)));
-                }else{
-                    var offsetX = gdo.net.node[gdo.clientId].sectionCol * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols-1));
-                    var offsetY =  gdo.net.node[gdo.clientId].sectionRow * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows*(gdo.net.section[gdo.net.instance[instanceId].sectionId].cols-1)));
+                    if (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols == 1) {
+                        var offsetX = gdo.net.node[gdo.clientId].sectionCol *
+                        (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols));
+                        var offsetY = 100 *
+                            gdo.net.node[gdo.clientId].sectionRow *
+                            (100 /
+                            (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows *
+                            (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols)));
+                    } else {
+                        var offsetX = gdo.net.node[gdo.clientId].sectionCol *
+                        (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols - 1));
+                        var offsetY = gdo.net.node[gdo.clientId].sectionRow *
+                        (100 /
+                        (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows *
+                        (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols - 1)));
+                    }
+                    var origin = offsetX + "% " + offsetY + "%";
+                    var width = gdo.net.section[gdo.net.instance[instanceId].sectionId].width /
+                        gdo.net.section[gdo.net.instance[instanceId].sectionId].cols;
+                    var height = gdo.net.section[gdo.net.instance[instanceId].sectionId].height;
+
+                } else {
+
+                    var offsetX = gdo.net.node[gdo.clientId].sectionCol *
+                    (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols - 1));
+                    var offsetY = gdo.net.node[gdo.clientId].sectionRow *
+                    (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows - 1));
+                    var origin = offsetX + "% " + offsetY + "%";
+                    var width = gdo.net.section[gdo.net.instance[instanceId].sectionId].width /
+                        gdo.net.section[gdo.net.instance[instanceId].sectionId].cols;
+                    var height = gdo.net.section[gdo.net.instance[instanceId].sectionId].height /
+                        gdo.net.section[gdo.net.instance[instanceId].sectionId].rows;
                 }
-                var origin = offsetX + "% " + offsetY + "%";
-                var width = gdo.net.section[gdo.net.instance[instanceId].sectionId].width/ gdo.net.section[gdo.net.instance[instanceId].sectionId].cols;
+                gdo.consoleOut('.StaticHTML', 4, origin);
+                $("iframe")
+                    .contents()
+                    .find("#html_frame")
+                    .attr("src", url)
+                    .css("zoom", 1)
+                    .css("-moz-transform", scale)
+                    .css("-moz-transform-origin", origin)
+                    .css("-o-transform", scale)
+                    .css("-o-transform-origin", origin)
+                    .css("-webkit-transform", scale)
+                    .css("-webkit-transform-origin", origin)
+                    .css("width", width + "px")
+                    .css("height", height + "px");
+
+            } else {
+                var screenWidth = gdo.net.section[gdo.net.instance[instanceId].sectionId].width /
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].cols;
+                var screenHeight = gdo.net.section[gdo.net.instance[instanceId].sectionId].height /
+                    gdo.net.section[gdo.net.instance[instanceId].sectionId].rows;
+
+                var xOffset = -gdo.net.node[gdo.clientId].sectionCol * screenWidth;
+                var yOffset = -gdo.net.node[gdo.clientId].sectionRow * screenHeight;
+                var width = gdo.net.section[gdo.net.instance[instanceId].sectionId].width;
                 var height = gdo.net.section[gdo.net.instance[instanceId].sectionId].height;
 
-            }else{
+                gdo.consoleOut('.StaticHTML', 0, 'ScreenWidth: ' + screenWidth + " ScreenHeight: " +
+                    screenHeight + " xOffset: " + xOffset + " yOffset: " + yOffset + " width: " +
+                    width + " height: " + height);
 
-                var offsetX = gdo.net.node[gdo.clientId].sectionCol * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].cols-1));
-                var offsetY = gdo.net.node[gdo.clientId].sectionRow * (100 / (gdo.net.section[gdo.net.instance[instanceId].sectionId].rows-1));
-                var origin = offsetX + "% " + offsetY + "%";
-                var width = gdo.net.section[gdo.net.instance[instanceId].sectionId].width / gdo.net.section[gdo.net.instance[instanceId].sectionId].cols;
-                var height = gdo.net.section[gdo.net.instance[instanceId].sectionId].height  / gdo.net.section[gdo.net.instance[instanceId].sectionId].rows;
+                var origin = "0% 0%";
+                var transform = "translate(" + xOffset + "px," + yOffset + "px)";
+
+                gdo.consoleOut('.StaticHTML', 0, 'Transform: ' + transform);
+
+                $("iframe")
+                    .contents()
+                    .find("#html_frame")
+                    .attr("src", url)
+                    .css("position", "absolute")
+                    .css("zoom", 1)
+                    .css("-moz-transform", transform)
+                    .css("-moz-transform-origin", origin)
+                    .css("-o-transform", transform)
+                    .css("-o-transform-origin", origin)
+                    .css("-webkit-transform", transform)
+                    .css("-webkit-transform-origin", origin)
+                    .css("width", width + "px")
+                    .css("height", height + "px");
             }
-            gdo.consoleOut('.StaticHTML', 4, origin);
-            $("iframe").contents().find("#html_frame")
-                .attr("src",url)
-                .css("zoom", 1)
-                .css("-moz-transform", scale)
-                .css("-moz-transform-origin", origin)
-                .css("-o-transform", scale)
-                .css("-o-transform-origin", origin)
-                .css("-webkit-transform", scale)
-                .css("-webkit-transform-origin", origin)
-                .css("width", width + "px")
-                .css("height", height + "px");
             gdo.consoleOut('.StaticHTML', 0, 'Loaded URL:' + url);
         }
     }

--- a/GDO.Apps.StaticHTML/StaticHTMLApp.cs
+++ b/GDO.Apps.StaticHTML/StaticHTMLApp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using GDO.Core;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.IO;
 using GDO.Core.Apps;
@@ -18,10 +19,13 @@ namespace GDO.Apps.StaticHTML
         public bool IntegrationMode { get; set; }
         public IAdvancedAppInstance ParentApp { get; set; }
 
+        public bool ResponsiveMode { get; set; }
         public string URL { get; set; }
         public void Init()
         {
-            URL = (string)Configuration.Json.SelectToken("url");;
+            URL = (string)Configuration.Json.SelectToken("url");
+            ResponsiveMode = (bool)(Configuration.Json.SelectToken("responsiveMode") ?? false);
+            Debug.WriteLine("Using responsive mode? " + ResponsiveMode);
         }
 
         public void SetURL(string url)

--- a/GDO.Apps.StaticHTML/StaticHTMLAppHub.cs
+++ b/GDO.Apps.StaticHTML/StaticHTMLAppHub.cs
@@ -31,9 +31,10 @@ namespace GDO.Apps.StaticHTML
             {
                 try
                 {
+                    bool responsiveMode = ((StaticHTMLApp) Cave.Apps["StaticHTML"].Instances[instanceId]).ResponsiveMode;
                     ((StaticHTMLApp)Cave.Apps["StaticHTML"].Instances[instanceId]).SetURL(url);
-                    Clients.Group("" + instanceId).receiveURL(instanceId, url);
-                    Clients.Caller.receiveURL(instanceId, url);
+                    Clients.Group("" + instanceId).receiveURL(instanceId, url, responsiveMode);
+                    Clients.Caller.receiveURL(instanceId, url, responsiveMode);
                 }
                 catch (Exception e)
                 {

--- a/GDO.Apps.StaticHTML/Web/StaticHTML/App.cshtml
+++ b/GDO.Apps.StaticHTML/Web/StaticHTML/App.cshtml
@@ -68,15 +68,18 @@
     <script src="../../Scripts/jquery-2.1.4.min.js"></script>
     <script src="../../Scripts/jquery.signalR-2.2.0.min.js"></script>
     <script src="../../Scripts/jquery.csv-0.71.min.js"></script>
-    <script>
-            $(function () {
-                $(document).ready(function () {
-                    var gdo = parent.gdo;
-                    gdo.net.app["StaticHTML"].initClient(gdo.clientId);
-                });
+<script>
+    $(function() {
+        $(document)
+            .ready(function() {
+                var gdo = parent.gdo;
+                gdo.net.app["StaticHTML"].initClient(gdo.clientId);
             });
-    </script>
-    <iframe id="html_frame" frameborder="0" style="border: 0 none; display: block; overflow:hidden;"></iframe>
+    });
+</script>
+    <div id="wrapper">
+        <iframe id="html_frame" frameborder="0" style="border: 0 none; display: block; overflow: hidden;"></iframe>
+    </div>
 
 </body>
 </html>


### PR DESCRIPTION
Responsive layout for StaticHTML app allows scaling over non 16:9 aspect ratio.
To launch use Responsive*.json config file.
ResponsiveBlack.json config file used to initialise to blank black html file to stop white flicker
