### PR TITLE
Retrieve Graph Fields when loading

### DIFF
--- a/GDO.Apps.Graph/GraphAppHub.cs
+++ b/GDO.Apps.Graph/GraphAppHub.cs
@@ -28,6 +28,36 @@ namespace GDO.Apps.Graph
             Groups.Remove(Context.ConnectionId, "" + groupId);
         }
 
+        public void GetFields(int instanceId)
+        {
+            lock (Cave.AppLocks[instanceId])
+            {
+                try
+                {
+           
+                    ga = (GraphApp) Cave.Apps["Graph"].Instances[instanceId];
+                    Clients.Caller.setMessage("Requesting fields...");
+                    if (((GraphApp) Cave.Apps["Graph"].Instances[instanceId]).graphinfo.NodeOtherFields != null)
+                    {
+                        Clients.Caller.setFields(
+                            ((GraphApp) Cave.Apps["Graph"].Instances[instanceId]).graphinfo.NodeOtherFields.ToArray(),
+                            instanceId);
+                        Clients.Caller.setMessage("Graph fields requested and sent successfully!");
+                    }
+                    else
+                    {
+                        Clients.Caller.setMessage("No Graph Fields");
+                    }
+                  
+                }
+                catch (Exception e)
+                {
+                    Clients.Caller.setMessage(e.ToString());
+                    Debug.WriteLine(e);
+                }
+            }
+        }
+
         public void InitiateProcessing(int instanceId, string filename)
         {
             Debug.WriteLine("Debug: Server side InitiateProcessing is called.");
@@ -56,7 +86,7 @@ namespace GDO.Apps.Graph
                     Clients.Caller.setMessage("Graph is now ready for zooming."); */
 
                     Clients.Caller.setMessage("Requesting fields...");
-                    Clients.Caller.setFields(((GraphApp)Cave.Apps["Graph"].Instances[instanceId]).graphinfo.NodeOtherFields.ToArray());
+                    Clients.Caller.setFields(((GraphApp)Cave.Apps["Graph"].Instances[instanceId]).graphinfo.NodeOtherFields.ToArray(), instanceId);
                     Clients.Caller.setMessage("Graph fields requested and sent successfully!");
                 }
                 catch (WebException e)

--- a/GDO.Apps.Graph/Scripts/Graph/gdo.apps.graph.js
+++ b/GDO.Apps.Graph/Scripts/Graph/gdo.apps.graph.js
@@ -82,10 +82,13 @@ $(function () {
     }
 
 
-    $.connection.graphAppHub.client.setFields = function (options) {
+    $.connection.graphAppHub.client.setFields = function (options, instanceId) {
+        // !!If you add and gdo.controlId check here, it will break the Twitter applications!!
         if (gdo.clientMode == gdo.CLIENT_MODE.CONTROL) {
             gdo.consoleOut('.Graph', 1, 'Set fields ');
 
+            gdo.net.instance[instanceId].graphFields = options;
+            gdo.net.instance[instanceId].graphFieldsLoaded = true;
             //add fields in loaded graph to the appropriate droplists
             var elem1 = $("iframe").contents().find("#select_label");
             var elem2 = $("iframe").contents().find("#select_SearchFields");
@@ -1383,7 +1386,9 @@ gdo.net.app["Graph"].initClient = function () {
 
 gdo.net.app["Graph"].initControl = function () {
     gdo.controlId = parseInt(getUrlVar("controlId"));
+    gdo.net.instance[gdo.clientId].graphFieldsLoaded = false;
     gdo.net.app["Graph"].server.requestRendering(gdo.controlId);
+    gdo.net.app["Graph"].server.getFields(gdo.controlId);
     gdo.consoleOut('.GRAPHRENDERER', 1, 'Initializing Graph Renderer App Control at Instance ' + gdo.controlId);
 }
 


### PR DESCRIPTION
Allow client to request fields from Hub, so if page refreshes you can still use interface.
