### PR TITLE
Images app auto launch v2.1

### DIFF
--- a/GDO.Apps.Images/ImagesAppHub.cs
+++ b/GDO.Apps.Images/ImagesAppHub.cs
@@ -708,7 +708,7 @@ namespace GDO.Apps.Images
 
                     double autoCropArea = 0.65;
                     double aspectRatio = ia.Section.Width / (0.0 + ia.Section.Height);
-                    double canvasAspectRatio = 1920.0 / 1080.0;
+                    //double canvasAspectRatio = 1920.0 / 1080.0;
                     // Image wrapper
                     double canvasHeight = 50 * windowHeight / 100; // height 50vh (convert vh to px)
                     double canvasWidth = windowWidth * 0.97 - 30 - 2; // wrapper 97%, padding 30, border 2


### PR DESCRIPTION
In previous version #135 I used fixed height(435px) and width to set initial position of cropbox, which result in a problem that the cropbox contains image cannot be auto centred after other app calling displayImage method (see below).
![capture](https://cloud.githubusercontent.com/assets/15330335/19541822/3cef82a8-9661-11e6-9ac8-9572ce4816bd.PNG)

This new version allows cropbox auto centred based on caller's brower size rather than fixed size but requires caller to pass two new parameters. Here is an example to call the new api:

`gdo.net.app["Images"].server.displayImage(instanceId, filename, 2, $("iframe")[0].contentWindow.width, $("iframe" [0].contentWindow.height);`

![capture2](https://cloud.githubusercontent.com/assets/15330335/19541846/97129392-9661-11e6-9765-97dfb8c4ef6c.PNG)
