### PR TITLE
Fix to make it possible to access AppHub-a from AppHub-b

### DIFF
--- a/GDO.Apps.BasicMaps/BasicMapsAppHub.cs
+++ b/GDO.Apps.BasicMaps/BasicMapsAppHub.cs
@@ -19,6 +19,7 @@ namespace GDO.Apps.BasicMaps
         public Type InstanceType { get; set; } = new BasicMapsApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Bitcoin/BitcoinAppHub.cs
+++ b/GDO.Apps.Bitcoin/BitcoinAppHub.cs
@@ -20,6 +20,7 @@ namespace GDO.Apps.Bitcoin
         public Type InstanceType { get; set; } = new BitcoinApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.City/CityAppHub.cs
+++ b/GDO.Apps.City/CityAppHub.cs
@@ -24,6 +24,7 @@ namespace GDO.Apps.City
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Cortical/CorticalAppHub.cs
+++ b/GDO.Apps.Cortical/CorticalAppHub.cs
@@ -20,6 +20,7 @@ namespace GDO.Apps.Cortical
         public Type InstanceType { get; set; } = new CorticalApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.DD3/DD3AppHub.cs
+++ b/GDO.Apps.DD3/DD3AppHub.cs
@@ -35,6 +35,7 @@ namespace GDO.Apps.DD3
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Fractals/FractalsAppHub.cs
+++ b/GDO.Apps.Fractals/FractalsAppHub.cs
@@ -18,6 +18,7 @@ namespace GDO.Apps.Fractals
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.FusionChart/FusionChartAppHub.cs
+++ b/GDO.Apps.FusionChart/FusionChartAppHub.cs
@@ -17,6 +17,7 @@ namespace GDO.Apps.FusionChart
         public Type InstanceType { get; set; } = new FusionChartApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.GigaImages/GigaImagesAppHub.cs
+++ b/GDO.Apps.GigaImages/GigaImagesAppHub.cs
@@ -15,6 +15,7 @@ namespace GDO.Apps.GigaImages
         public Type InstanceType { get; set; } = new GigaImagesApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Graph/GraphAppHub.cs
+++ b/GDO.Apps.Graph/GraphAppHub.cs
@@ -21,6 +21,7 @@ namespace GDO.Apps.Graph
         public Type InstanceType { get; set; } = new GraphApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.HelloWorld/HelloWorldAppHub.cs
+++ b/GDO.Apps.HelloWorld/HelloWorldAppHub.cs
@@ -23,6 +23,7 @@ namespace GDO.Apps.HelloWorld {
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Images/ImagesAppHub.cs
+++ b/GDO.Apps.Images/ImagesAppHub.cs
@@ -20,6 +20,7 @@ namespace GDO.Apps.Images
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
 

--- a/GDO.Apps.Leeds/LeedsAppHub.cs
+++ b/GDO.Apps.Leeds/LeedsAppHub.cs
@@ -16,6 +16,7 @@ namespace GDO.Apps.Leeds
         public Type InstanceType { get; set; } = new LeedsApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.LondonCycles/LondonCyclesAppHub.cs
+++ b/GDO.Apps.LondonCycles/LondonCyclesAppHub.cs
@@ -17,6 +17,7 @@ namespace GDO.Apps.LondonCycles
         public Type InstanceType { get; set; } = new LondonCyclesApp().GetType();
         public void JoinGroup(string groupId)
         {
+			Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Maps/MapsAppHub.cs
+++ b/GDO.Apps.Maps/MapsAppHub.cs
@@ -27,6 +27,7 @@ namespace GDO.Apps.Maps
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Presentation/PresentationAppHub.cs
+++ b/GDO.Apps.Presentation/PresentationAppHub.cs
@@ -24,6 +24,7 @@ namespace GDO.Apps.Presentation
         public Type InstanceType { get; set; } = new PresentationApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.RayMarching/RayMarchingAppHub.cs
+++ b/GDO.Apps.RayMarching/RayMarchingAppHub.cs
@@ -18,6 +18,7 @@ namespace GDO.Apps.RayMarching
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.SAGE2/SAGE2AppHub.cs
+++ b/GDO.Apps.SAGE2/SAGE2AppHub.cs
@@ -18,6 +18,7 @@ namespace GDO.Apps.SAGE2
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.ShanghaiMetro/ShanghaiMetroAppHub.cs
+++ b/GDO.Apps.ShanghaiMetro/ShanghaiMetroAppHub.cs
@@ -19,6 +19,7 @@ namespace GDO.Apps.ShanghaiMetro
         public Type InstanceType { get; set; } = new ShanghaiMetroApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Spreadsheets/SpreadsheetsAppHub.cs
+++ b/GDO.Apps.Spreadsheets/SpreadsheetsAppHub.cs
@@ -15,6 +15,7 @@ namespace GDO.Apps.Spreadsheets
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.StaticHTML/StaticHTMLAppHub.cs
+++ b/GDO.Apps.StaticHTML/StaticHTMLAppHub.cs
@@ -19,6 +19,7 @@ namespace GDO.Apps.StaticHTML
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Temperatures/TemperaturesAppHub.cs
+++ b/GDO.Apps.Temperatures/TemperaturesAppHub.cs
@@ -20,6 +20,7 @@ namespace GDO.Apps.Temperatures {
         public Type InstanceType { get; set; } = new TemperaturesApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Twitter/TwitterAppHub.cs
+++ b/GDO.Apps.Twitter/TwitterAppHub.cs
@@ -19,6 +19,7 @@ namespace GDO.Apps.Twitter
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
 

--- a/GDO.Apps.UKTravel/UKTravelAppHub.cs
+++ b/GDO.Apps.UKTravel/UKTravelAppHub.cs
@@ -17,6 +17,7 @@ namespace GDO.Apps.UKTravel
         public Type InstanceType { get; set; } = new UKTravelApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.WebGL/WebGLAppHub.cs
+++ b/GDO.Apps.WebGL/WebGLAppHub.cs
@@ -17,6 +17,7 @@ namespace GDO.Apps.WebGL
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.Youtube/YoutubeAppHub.cs
+++ b/GDO.Apps.Youtube/YoutubeAppHub.cs
@@ -18,6 +18,7 @@ namespace GDO.Apps.Youtube
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.YoutubeWall/YoutubeWallAppHub.cs
+++ b/GDO.Apps.YoutubeWall/YoutubeWallAppHub.cs
@@ -20,6 +20,7 @@ namespace GDO.Apps.YoutubeWall
         public Type InstanceType { get; set; } = new YoutubeWallApp().GetType();
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO.Apps.tranSMART/tranSMARTAppHub.cs
+++ b/GDO.Apps.tranSMART/tranSMARTAppHub.cs
@@ -18,6 +18,7 @@ namespace GDO.Apps.tranSMART
 
         public void JoinGroup(string groupId)
         {
+            Cave.Apps[Name].Hub.Clients = Clients;
             Groups.Add(Context.ConnectionId, "" + groupId);
         }
         public void ExitGroup(string groupId)

--- a/GDO/Core/Apps/App.cs
+++ b/GDO/Core/Apps/App.cs
@@ -23,6 +23,8 @@ namespace GDO.Core.Apps
         public List<string> ConfigurationList { get; set; }
         [JsonIgnore]
         public ConcurrentDictionary<int,IAppInstance> Instances { get; set; }
+        [JsonIgnore]
+        public IAppHub Hub { get; set; }
 
         public App()
         {

--- a/GDO/Core/Cave.cs
+++ b/GDO/Core/Cave.cs
@@ -460,6 +460,7 @@ namespace GDO.Core
                     Log.Info("registering an app configuration for app " + name + " called " + configuration.Name);
                     Apps[name].Configurations.TryAdd(configuration.Name, configuration);
                 }
+                Apps[name].Hub = appHub;
                 return true;
             }
             return false;


### PR DESCRIPTION
This fix is a followup from discussion "conclusions from discussion on improving the GDO framework" between @davidbirchwork, @bkavuncu, @miguems, @JingqingZ and @senakafdo. This makes it possible to access any AppHub from any other AppHub.

For example, the following code can be executed from within the TwitterAppHub after adding the required references. The instanceId needs not always be 0.
`((YoutubeWallAppHub)Cave.Apps["YoutubeWall"].Hub).UnMuteAll(0);`